### PR TITLE
Extra line of POD for LICENSE file fulltext

### DIFF
--- a/lib/Pod/Weaver/Section/Legal.pm
+++ b/lib/Pod/Weaver/Section/Legal.pm
@@ -19,6 +19,10 @@ information for the document, like this:
 This plugin will do nothing if no C<license> input parameter is available.  The
 C<license> is expected to be a L<Software::License> object.
 
+If a L<Dist::Zilla> object is provided and the distribution contains a F<LICENSE>
+file, an extra line of text will be added telling users to check the file for the
+full text of the license.
+
 =cut
 
 sub weave_section {
@@ -28,6 +32,17 @@ sub weave_section {
 
   my $notice = $input->{license}->notice;
   chomp $notice;
+
+  if ( $input->{zilla} ) {
+    # TODO dzil docs claim that the file representation might change...
+    foreach my $f ( @{ $input->{zilla}->files } ) {
+      if ( $f->name eq 'LICENSE' ) {
+        $notice .= "\n\nThe full text of the license can be found";
+        $notice .= " in the LICENSE file included with this distribution.";
+        last;
+      }
+    }
+  }
 
   $document->children->push(
     Pod::Elemental::Element::Nested->new({


### PR DESCRIPTION
Hello,

 While browsing some POD, I noticed that they contained this line:

The full text of the license can be found in the LICENSE file included with this distribution.

 I thought this was a cool idea, and this patch adds it if a zilla object is provided and it contains a LICENSE file in it.

Thanks!
