### PR TITLE
split ::Section::Version::weave_section() into multiple methods

### DIFF
--- a/lib/Pod/Weaver/Section/Version.pm
+++ b/lib/Pod/Weaver/Section/Version.pm
@@ -106,7 +106,7 @@ has time_zone => (
   default => 'local',
 );
 
-sub weave_section {
+sub weave_section_content {
   my ($self, $document, $input) = @_;
   return unless $input->{version};
 
@@ -133,11 +133,20 @@ sub weave_section {
     });
   }
 
+  return ($content);
+}
+
+sub weave_section {
+  my ($self, $document, $input) = @_;
+  return unless $input->{version};
+
+  my @content = $self->weave_section_content($document, $input);
+
   $document->children->push(
     Pod::Elemental::Element::Nested->new({
       command  => 'head1',
       content  => 'VERSION',
-      children => [ $content ],
+      children => \@content,
     }),
   );
 }


### PR DESCRIPTION
I'd like to have my version sections give some indication of the (fuzzy) relative stability of the package; this would be made easier if I could just append parts to the version section being generated, rather than find the section, append, etc.  This change makes that possible, by splitting the content generation parts out of weave_section() and into their own method.

I'm fairly confident this is a sane/reasonable approach, but if not, I won't take umbrage at being corrected :)
