### PR TITLE
Fix Transformer example so it actually works

### DIFF
--- a/lib/Pod/Weaver/Plugin/Transformer.pm
+++ b/lib/Pod/Weaver/Plugin/Transformer.pm
@@ -15,7 +15,7 @@ This plugin acts as a L<Pod::Weaver::Role::Dialect> that applies an arbitrary
 L<Pod::Elemental::Transformer> to your input document.  It is configured like
 this:
 
-  [Transformer / Lists]
+  [-Transformer / Lists]
   transformer = List
   format_name = outline
 


### PR DESCRIPTION
`[Transformer / Lists]` doesn't work, because it's a Plugin, not a Section
