### PR TITLE
Add a helpful hint about how to fix a missing PODNAME comment

### DIFF
--- a/lib/Pod/Weaver/Section/Name.pm
+++ b/lib/Pod/Weaver/Section/Name.pm
@@ -102,7 +102,7 @@ sub weave_section {
   my $docname  = $self->_get_docname($input);
   my $abstract = $self->_get_abstract($input);
 
-  Carp::croak sprintf "couldn't determine document name for %s", $filename
+  Carp::croak sprintf "couldn't determine document name for %s\nAdd something like this to %s:\n# PODNAME: bobby_tables.pl", $filename, $filename
     unless $docname;
 
   $self->log([ "couldn't find abstract in %s", $filename ]) unless $abstract;


### PR DESCRIPTION
I ran into this using Dist::Zilla on a Dancer project with PodWeaver.
