### PR TITLE
use filename POD formatting code for license file

### DIFF
--- a/lib/Pod/Weaver/Section/Legal.pm
+++ b/lib/Pod/Weaver/Section/Legal.pm
@@ -45,8 +45,8 @@ sub weave_section {
   chomp $notice;
 
   if ( $self->_has_license_file ) {
-    $notice .= "\n\nThe full text of the license can be found in the\n'";
-    $notice .= $self->license_file . "' file included with this distribution.";
+    $notice .= "\n\nThe full text of the license can be found in the\nF<";
+    $notice .= $self->license_file . "> file included with this distribution.";
   }
 
   $document->children->push(

--- a/t/eg/legal_t2.out.pod
+++ b/t/eg/legal_t2.out.pod
@@ -30,6 +30,6 @@ This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
 
 The full text of the license can be found in the
-'LICENSE' file included with this distribution.
+F<LICENSE> file included with this distribution.
 
 =cut


### PR DESCRIPTION
POD offers formatting code `F<>` for use with filenames.  It seems sensible to give semantic meaning to the filename by using that code.
