### PR TITLE
Document [-SingleEncoding] plugin

### DIFF
--- a/lib/Pod/Weaver/PluginBundle/Default.pm
+++ b/lib/Pod/Weaver/PluginBundle/Default.pm
@@ -12,6 +12,8 @@ fairly conservative and straightforward.
 It is nearly equivalent to the following:
 
   [@CorePrep]
+  
+  [-SingleEncoding]
 
   [Name]
   [Version]


### PR DESCRIPTION
This is necessary for people who have customized their `weaver.ini` to include other plugins/sections
