### PR TITLE
Added ability for Pod::Weaver to determine NAME section from filenames f...

### DIFF
--- a/lib/Pod/Weaver/Section/Name.pm
+++ b/lib/Pod/Weaver/Section/Name.pm
@@ -2,6 +2,8 @@ package Pod::Weaver::Section::Name;
 # ABSTRACT: add a NAME section with abstract (for your Perl module)
 
 use Moose;
+use File::Basename;
+
 with 'Pod::Weaver::Role::Section';
 with 'Pod::Weaver::Role::StringFromComment';
 
@@ -25,6 +27,9 @@ must be given.  It looks for comments in the form:
 
 If no C<PODNAME> comment is present, but a package declaration can be found,
 the package name will be used as the document name.
+
+If no C<PODNAME> comment or package declaration is present, for files whose names 
+do not match C<*.pm> the filename will be used as the document name.
 
 =cut
 
@@ -52,7 +57,8 @@ sub _get_docname {
   my $ppi_document = $input->{ppi_document};
 
   my $docname = $self->_get_docname_via_comment($ppi_document)
-             || $self->_get_docname_via_statement($ppi_document);
+             || $self->_get_docname_via_statement($ppi_document)
+             || ($ppi_document->can('filename') && $ppi_document->filename !~ m/.*pm/ && basename($ppi_document->filename));
 
   return $docname;
 }

--- a/t/eg/script_name_t1.in.pl
+++ b/t/eg/script_name_t1.in.pl
@@ -1,0 +1,5 @@
+#!/usr/bin/env perl
+# ABSTRACT: abstract text
+
+my $this = 'a test';
+

--- a/t/eg/script_name_t1.in.pod
+++ b/t/eg/script_name_t1.in.pod
@@ -1,0 +1,21 @@
+=pod
+
+=head1 DESCRIPTION
+
+This is a simple document meant to be used in testing Pod::Weaver.
+
+It does not do very much.
+
+=head1 BE FOREWARNED
+
+This is not supported:
+
+  much at all
+
+Happy hacking!
+
+=head1 SYNOPSIS
+
+This should probably get moved up front.
+
+=cut

--- a/t/eg/script_name_t1.out.pod
+++ b/t/eg/script_name_t1.out.pod
@@ -1,0 +1,29 @@
+=pod
+
+=head1 NAME
+
+script_name_t1.in.pl - abstract text
+
+=head1 VERSION
+
+version 1.012078
+
+=head1 DESCRIPTION
+
+This is a simple document meant to be used in testing Pod::Weaver.
+
+It does not do very much.
+
+=head1 BE FOREWARNED
+
+This is not supported:
+
+  much at all
+
+Happy hacking!
+
+=head1 SYNOPSIS
+
+This should probably get moved up front.
+
+=cut

--- a/t/script_name.t
+++ b/t/script_name.t
@@ -1,0 +1,57 @@
+#  Mostly lifted from version_without_package.t but with different data section.
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Differences;
+
+use PPI;
+
+use Pod::Elemental;
+use Pod::Weaver;
+
+do_weave( configer( ), 'script_name_t1' );
+
+sub configer {
+  my %opts = @_;
+
+  # TODO Hmpf, is there an easier way for this? --APOCAL
+  my $assembler = Pod::Weaver::Config::Assembler->new;
+  $assembler->sequence->add_section( $assembler->section_class->new({ name => '_' }) );
+  $assembler->change_section('@CorePrep');
+  $assembler->change_section('Name');
+  $assembler->change_section('Version');
+  foreach my $k ( keys %opts ) {
+    $assembler->add_value( $k => $opts{ $k } );
+  }
+  $assembler->change_section('Leftovers');
+
+  return Pod::Weaver->new_from_config_sequence( $assembler->sequence );
+}
+
+sub do_weave {
+  my( $weaver, $filename ) = @_;
+
+  my $in_pod   = do { local $/; open my $fh, '<:raw:bytes', "t/eg/$filename.in.pod"; <$fh> };
+  my $expected = do { local $/; open my $fh, '<:encoding(UTF-8)', "t/eg/$filename.out.pod"; <$fh> };
+  my $document = Pod::Elemental->read_string($in_pod);
+
+  my $ppi_document  = PPI::Document::File->new("t/eg/$filename.in.pl");
+
+  my $woven = $weaver->weave_document({
+    pod_document => $document,
+    ppi_document => $ppi_document,
+    version  => '1.012078',
+  });
+
+  # XXX: This test is extremely risky as things change upstream.
+  # -- rjbs, 2009-10-23
+  eq_or_diff(
+    $woven->as_pod_string,
+    $expected,
+    "exactly the pod string we wanted after weaving for $filename!",
+  );
+}
+
+done_testing;
+


### PR DESCRIPTION
...or non-module (i.e. script) files.

Hi Ricardo,

I think this addresses issue #29 - I hit the same one recently with a distribution I'm converting to use Dist::Zilla. I've included a test script as well, copied and modified from one of the existing tests.

Hope this helps!

Cheers

Brad
