### PR TITLE
do not decode strings coming from PPI

### DIFF
--- a/lib/Pod/Weaver/Section/Name.pm
+++ b/lib/Pod/Weaver/Section/Name.pm
@@ -5,8 +5,6 @@ use Moose;
 with 'Pod::Weaver::Role::Section';
 with 'Pod::Weaver::Role::StringFromComment';
 
-use Encode;
-
 =head1 OVERVIEW
 
 This section plugin will produce a hunk of Pod giving the name of the document
@@ -87,10 +85,8 @@ sub weave_section {
 
   my $filename = $input->{filename} || 'file';
 
-  # We can do this becaue we know that PPI is working on bytes.  If PPI ever
-  # becomes a string parser, we'll need to rethink. -- rjbs, 2014-11-12
-  my $docname  = Encode::decode_utf8($self->_get_docname($input));
-  my $abstract = Encode::decode_utf8($self->_get_abstract($input));
+  my $docname  = $self->_get_docname($input);
+  my $abstract = $self->_get_abstract($input);
 
   Carp::croak sprintf "couldn't determine document name for %s\nAdd something like this to %s:\n# PODNAME: bobby_tables.pl", $filename, $filename
     unless $docname;

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use utf8;
 use Test::More;
 use Test::Differences;
 

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use utf8;
 use Test::More;
 use Test::Differences;
 

--- a/t/ini-config.t
+++ b/t/ini-config.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 
+use utf8;
 use Test::More;
 use Test::Differences;
 


### PR DESCRIPTION
We can usually get away with this, because either the characters are ascii, or
PPI was called with Dist::Zilla::Role::PPI pre-6.003 where we encoded the
document content before passing it to PPI. Now we don't do this, so we can now
get "Cannot decode string with wide characters" errors.