### PR TITLE
make sure to skip sections we don't have info for

### DIFF
--- a/lib/Pod/Weaver/Section/Bugs.pm
+++ b/lib/Pod/Weaver/Section/Bugs.pm
@@ -68,6 +68,7 @@ sub weave_section {
 
   unless (defined $web || defined $mailto) {
     $self->log_debug('skipping section because there is no web or mailto key under resources.bugtracker');
+    return;
   }
 
   my $text = "Please report any bugs or feature requests ";

--- a/lib/Pod/Weaver/Section/Legal.pm
+++ b/lib/Pod/Weaver/Section/Legal.pm
@@ -51,6 +51,7 @@ sub weave_section {
 
   unless ($input->{license}) {
     $self->log_debug('no license specified, not adding a ' . $self->header . ' section');
+    return;
  }
 
   my $notice = $input->{license}->notice;


### PR DESCRIPTION
PR #42 added some debug logging, but in doing so, removed some of the
return statements that skipped sections. This caused a test to fail in
Statocles (preaction/Statocles#513)

This also includes the same changes as #43