### PR TITLE
keep =for and =begin sections together with the =head1 they were found under

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Pod-Weaver
 
 {{$NEXT}}
+        - H1Nester now also captures =for and =begin tags under =head1
 
 4.015     2016-10-14 20:48:13-04:00 America/New_York
         - fix bugs introduced in 4.014 that would cause [Bugs] and [Legal]

--- a/lib/Pod/Weaver/Plugin/H1Nester.pm
+++ b/lib/Pod/Weaver/Plugin/H1Nester.pm
@@ -24,7 +24,7 @@ sub transform_document {
     top_selector => s_command([ qw(head1) ]),
     content_selectors => [
       s_flat,
-      s_command( [ qw(head2 head3 head4 over item back) ]),
+      s_command( [ qw(head2 head3 head4 over item for begin back) ]),
     ],
   });
 


### PR DESCRIPTION
This means that elements such as stopwords and lists will get moved along with
the head1 sections they were declared under, when that section is moved to
another position in the document.